### PR TITLE
Add clock and exit features

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,20 @@ Generates a short "beep" using the Web Audio API when buttons are clicked.
 ✅ **Built-in Star Trek Data**
 Includes a JSON file with information about the TV series to demonstrate data integration.
 
-✅ **Componentized Structure**  
+✅ **Componentized Structure**
 Easy-to-extend with new buttons, pages, animations, or data integrations.
 
 ✅ **No Local Assets Required**
 Fonts are loaded from Google Fonts and sounds are generated dynamically.
 
-✅ **Fullscreen-Ready**  
+✅ **Fullscreen-Ready**
 Can be run in fullscreen or kiosk mode — perfect for touch panels or retro setups.
+
+✅ **Real-Time Clock**
+Displays the current system time in the interface.
+
+✅ **Exit Button**
+Quickly close the application from the UI.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
 </head>
 <body>
   <div id="wrapper">
+    <div id="top-bar">
+      <span id="clock"></span>
+      <button class="lcars-button small" id="exit-btn">Exit</button>
+    </div>
     <div id="left-bar">
       <button class="lcars-button" id="main-btn">Activate</button>
     </div>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
 
 function createWindow() {
@@ -19,4 +19,8 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
   }
+});
+
+ipcMain.on('close-app', () => {
+  app.quit();
 });

--- a/preload.js
+++ b/preload.js
@@ -1,3 +1,5 @@
-window.addEventListener('DOMContentLoaded', () => {
-  // placeholder for preload logic
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  closeApp: () => ipcRenderer.send('close-app')
 });

--- a/renderer.js
+++ b/renderer.js
@@ -1,6 +1,15 @@
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('main-btn');
+  const exitBtn = document.getElementById('exit-btn');
+  const clock = document.getElementById('clock');
   const ctx = new (window.AudioContext || window.webkitAudioContext)();
+
+  function updateClock() {
+    const now = new Date();
+    clock.textContent = now.toLocaleTimeString();
+  }
+  updateClock();
+  setInterval(updateClock, 1000);
 
   function playBeep() {
     const osc = ctx.createOscillator();
@@ -29,5 +38,9 @@ document.addEventListener('DOMContentLoaded', () => {
         content.classList.remove('hidden');
         btn.textContent = 'Activate';
       });
+  });
+
+  exitBtn.addEventListener('click', () => {
+    window.electronAPI.closeApp();
   });
 });

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,17 @@
   height: 100vh;
 }
 
+#top-bar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 10px 20px;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  font-family: 'Orbitron', sans-serif;
+}
+
 body {
   margin: 0;
   background: #000;
@@ -43,6 +54,11 @@ body {
   cursor: pointer;
   font-family: 'Orbitron', sans-serif;
   transition: background 0.3s ease;
+}
+
+.lcars-button.small {
+  padding: 5px 15px;
+  font-size: 0.9em;
 }
 
 .lcars-button:hover {


### PR DESCRIPTION
## Summary
- add a top bar with real-time clock and exit button
- update styles for new elements
- expose `electronAPI.closeApp` through preload script
- handle `close-app` event in main process
- document new features in README

## Testing
- `npm test` *(fails: Missing script)*
- `xvfb-run --auto-servernum npm start` *(fails: GPU/DBus errors in container)*

------
https://chatgpt.com/codex/tasks/task_e_6857266c126083279fe6129feda08571