### PR TITLE
Add theme engine, plugin system, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ Rounded panels and colored bars provide a closer LCARS look and feel.
 ✅ **Randomized Beeps**
 Each interaction plays a slightly different tone for more authentic feedback.
 
+✅ **Theme Switcher**
+Toggle between predefined color themes at runtime.
+
+✅ **Dynamic Font Loading**
+Fonts are loaded programmatically for better control and caching.
+
+✅ **Plugin System**
+External JavaScript modules can register new buttons and panels.
+
+✅ **System Status Plugin**
+Ships with an example plugin that shows live system information.
+
 ---
 
 ## 📁 Project Structure

--- a/docs/features_order.md
+++ b/docs/features_order.md
@@ -1,0 +1,30 @@
+# LCARS OS Feature Build Order
+
+This document outlines the recommended order for implementing the major LCARS OS features. Each section briefly describes the feature and the basic steps to integrate it into the application.
+
+## 1. LCARS Panel Layout & Rounded Buttons
+- Establish a flexible panel layout using CSS Flexbox or Grid.
+- Create reusable button styles with asymmetric rounded corners.
+- Support vertical and horizontal panel orientations.
+
+## 2. Theme Engine & Dynamic Font Loading
+- Define CSS variables for colors and fonts.
+- Implement a simple theme switcher that toggles CSS variables at runtime.
+- Load LCARS-style fonts dynamically from Google Fonts or local assets.
+
+## 3. System Status Panel
+- Use Node's `os` module to gather CPU, memory, and storage data.
+- Display this information in a dedicated panel with LCARS-styled graphs or bars.
+- Update the stats at regular intervals to keep the panel live.
+
+## 4. Plugin/Extension Support
+- Create a `plugins/` directory where JavaScript modules can be loaded dynamically.
+- Expose a registration API in `renderer.js` so plugins can add buttons or panels.
+- Example plugin ideas: weather widget, mini games, smart home controller.
+
+## 5. Additional Enhancements
+- Audio feedback for buttons and alerts.
+- Ambient bridge sounds or voice feedback.
+- Hotkeys, gestures, and kiosk mode options.
+
+Use this roadmap as a starting point for development. Tackle each feature sequentially to build a solid LCARS-inspired interface.

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <div id="wrapper">
     <div id="top-bar">
       <span id="clock"></span>
+      <button class="lcars-button small" id="theme-btn">Theme</button>
       <button class="lcars-button small" id="exit-btn">Exit</button>
     </div>
     <div id="left-bar">
@@ -20,6 +21,6 @@
     </div>
     <div id="content" class="hidden"></div>
   </div>
-  <script src="renderer.js"></script>
+  <script type="module" src="renderer.js"></script>
 </body>
 </html>

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -1,0 +1,3 @@
+[
+  "systemStatus"
+]

--- a/plugins/systemStatus.js
+++ b/plugins/systemStatus.js
@@ -1,0 +1,25 @@
+export function init({ registerButton, playBeep }) {
+  registerButton('Status', async () => {
+    playBeep();
+    const content = document.getElementById('content');
+    content.innerHTML = '<h2>System Status</h2><div id="status-panel">Loading...</div>';
+    content.classList.remove('hidden');
+    update();
+  });
+
+  async function update() {
+    const info = await window.electronAPI.getSystemInfo();
+    const panel = document.getElementById('status-panel');
+    if (panel) {
+      panel.innerHTML = `
+        <ul>
+          <li>Platform: ${info.platform}</li>
+          <li>Architecture: ${info.arch}</li>
+          <li>CPU Cores: ${info.cpus}</li>
+          <li>Total Memory: ${info.memory} GB</li>
+        </ul>`;
+    }
+  }
+
+  setInterval(update, 5000);
+}

--- a/renderer.js
+++ b/renderer.js
@@ -4,8 +4,53 @@ document.addEventListener('DOMContentLoaded', () => {
   const exitBtn = document.getElementById('exit-btn');
   const sysInfoBtn = document.getElementById('sysinfo-btn');
   const clearBtn = document.getElementById('clear-btn');
+  const themeBtn = document.getElementById('theme-btn');
   const clock = document.getElementById('clock');
   const ctx = new (window.AudioContext || window.webkitAudioContext)();
+
+  const pluginArea = document.getElementById('left-bar');
+
+  function registerButton(label, handler) {
+    const button = document.createElement('button');
+    button.className = 'lcars-button';
+    button.textContent = label;
+    button.addEventListener('click', handler);
+    pluginArea.appendChild(button);
+  }
+
+  function loadFont(name, url) {
+    const font = new FontFace(name, `url(${url})`);
+    return font.load().then(() => {
+      document.fonts.add(font);
+    });
+  }
+
+  loadFont('Share Tech Mono', 'https://fonts.gstatic.com/s/sharetechmono/v15/J7aHnp1uDWRBEqV98dVQ5mRY1yo.woff2');
+  loadFont('Orbitron', 'https://fonts.gstatic.com/s/orbitron/v30/yMJRMIlzdpvBhQQL_Qq7dytiyr2GqCJDM8c.woff2');
+
+  function applyStoredTheme() {
+    const theme = localStorage.getItem('lcars-theme');
+    if (theme === 'alt') {
+      document.body.setAttribute('data-theme', 'alt');
+    }
+  }
+  applyStoredTheme();
+
+  async function loadPlugins() {
+    try {
+      const res = await fetch('plugins/plugins.json');
+      const plugins = await res.json();
+      for (const name of plugins) {
+        const mod = await import(`./plugins/${name}.js`);
+        if (mod.init) {
+          mod.init({ registerButton, playBeep });
+        }
+      }
+    } catch (err) {
+      console.error('Plugin loading failed', err);
+    }
+  }
+  loadPlugins();
 
   function updateClock() {
     const now = new Date();
@@ -78,6 +123,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const content = document.getElementById('content');
     content.classList.add('hidden');
     content.innerHTML = '';
+  });
+
+  themeBtn.addEventListener('click', () => {
+    playBeep();
+    const isAlt = document.body.getAttribute('data-theme') === 'alt';
+    if (isAlt) {
+      document.body.removeAttribute('data-theme');
+      localStorage.setItem('lcars-theme', 'default');
+    } else {
+      document.body.setAttribute('data-theme', 'alt');
+      localStorage.setItem('lcars-theme', 'alt');
+    }
   });
 
   exitBtn.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,19 @@
+:root {
+  --panel-bg: #9932CC;
+  --button-bg: #FF6633;
+  --button-bg-hover: #FF9966;
+  --top-bg: #330066;
+  --text-color: #fff;
+  --body-bg: #000;
+}
+
+body[data-theme='alt'] {
+  --panel-bg: #003366;
+  --button-bg: #6699FF;
+  --button-bg-hover: #99BBFF;
+  --top-bg: #001133;
+}
+
 #wrapper {
   display: flex;
   height: 100vh;
@@ -12,21 +28,21 @@
   gap: 10px;
   align-items: center;
   font-family: 'Orbitron', sans-serif;
-  background: #330066;
+  background: var(--top-bg);
   border-bottom-left-radius: 20px;
 }
 
 body {
   margin: 0;
-  background: #000;
+  background: var(--body-bg);
   font-family: 'Share Tech Mono', monospace;
-  color: #fff;
+  color: var(--text-color);
   overflow: hidden;
 }
 
 #left-bar {
   width: 200px;
-  background: #9932CC;
+  background: var(--panel-bg);
   border-top-right-radius: 20px;
   border-bottom-right-radius: 20px;
   padding: 20px;
@@ -39,7 +55,7 @@ body {
 
 #content {
   flex: 1;
-  background: #000;
+  background: var(--body-bg);
   padding: 40px;
   overflow-y: auto;
   animation: fadeIn 1s ease forwards;
@@ -51,7 +67,7 @@ body {
 }
 
 .lcars-button {
-  background: #FF6633;
+  background: var(--button-bg);
   border: none;
   padding: 15px 30px;
   font-size: 1.2em;
@@ -68,7 +84,7 @@ body {
 }
 
 .lcars-button:hover {
-  background: #FF9966;
+  background: var(--button-bg-hover);
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- add CSS variable based theming and a Theme button
- load fonts dynamically and switch themes at runtime
- introduce plugin loader with example System Status plugin
- document feature build order
- list new features in README

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint` *(fails: Missing script 'lint')*

------
https://chatgpt.com/codex/tasks/task_e_68572af579788327aed57e8ba49ddb42