### PR TITLE
Integrate scanner plugin

### DIFF
--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -2,5 +2,6 @@
   "systemStatus",
   "weather",
   "starshipStatus",
-  "stardate"
+  "stardate",
+  "scanner"
 ]

--- a/plugins/scanner.js
+++ b/plugins/scanner.js
@@ -1,0 +1,14 @@
+export function init({ registerButton, playBeep, speak }) {
+  registerButton('Scanner', () => {
+    playBeep();
+    speak('Activating forward scanner');
+    const content = document.getElementById('content');
+    content.innerHTML = `
+      <div class="scanner-container">
+        <div class="scanner"><div><div class="select-left"><div class="select-bracket"></div></div><div class="select-right"><div class="select-bracket"></div></div></div></div>
+        <div class="scanner"><div><div class="select-left"><div class="select-bracket"></div></div><div class="select-right"><div class="select-bracket"></div></div></div></div>
+        <div class="scanner"><div><div class="select-left"><div class="select-bracket"></div></div><div class="select-right"><div class="select-bracket"></div></div></div></div>
+      </div>`;
+    content.classList.remove('hidden');
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -91,3 +91,71 @@ body {
   from { opacity: 0; }
   to { opacity: 1; }
 }
+
+/* Scanner overlay inspired by louh/lcars */
+#content {
+  position: relative;
+}
+
+.scanner-container,
+.scanner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.scanner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.scanner > div:first-child {
+  position: relative;
+  animation: scanner-scale 6s cubic-bezier(0, 0, 0.9, 1) infinite;
+  opacity: 0;
+  border-radius: 8px;
+}
+
+.scanner:nth-child(1) > div:first-child { animation-delay: 2s; }
+.scanner:nth-child(2) > div:first-child { animation-delay: 4s; }
+
+.select-left,
+.select-right {
+  position: absolute;
+  top: -5px;
+  height: calc(100% + 10px);
+  width: 28px;
+  overflow: hidden;
+}
+.select-left { left: 0; }
+.select-right { right: 0; }
+
+.select-bracket {
+  position: absolute;
+  width: 60px;
+  height: 100%;
+  border: 12px solid var(--button-bg);
+  border-top-width: 10px;
+  border-bottom-width: 10px;
+  border-radius: 24px / 16px;
+}
+.select-left .select-bracket { left: 0; }
+.select-right .select-bracket { right: 0; }
+
+@keyframes scanner-scale {
+  from {
+    width: 10%;
+    height: 10%;
+    background-color: rgba(255, 255, 255, 0.075);
+    opacity: 1;
+  }
+  to {
+    width: 95%;
+    height: 95%;
+    background-color: rgba(255, 255, 255, 0.05);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `scanner` plugin to show a LCARS-style scanning overlay
- register the plugin in the plugin loader
- implement scanner CSS styles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857356a45f083279e3bdc532ce3d47e