### PR TITLE
Add voice selection plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Generates a short "beep" using the Web Audio API when buttons are clicked.
 
 ✅ **LCARS Voice**
 Each action is accompanied by speech using the Web Speech API.
+✅ **Voice Selection Plugin**
+Choose your preferred speech synthesis voice, stored for future sessions.
 
 ✅ **Built-in Star Trek Data**
 Includes JSON files with information about the TV series and famous quotes to demonstrate data integration.
@@ -97,6 +99,12 @@ Displays a Starfleet command message with logo.
 Shows the iconic omega symbol and secret protocol text.
 ✅ **Numbers Table Plugin**
 Generates rows of random digits like the original LCARS demo.
+
+## 🎤 Voice Selection
+
+Use the **Voice** button in the sidebar to pick from any installed speech
+synthesis voices. Your choice is saved in local storage so the interface will
+continue speaking with that voice on the next launch.
 
 ## 📁 Project Structure
 

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -1,4 +1,5 @@
 [
+  "voiceSelector",
   "systemStatus",
   "weather",
   "starshipStatus",

--- a/plugins/voiceSelector.js
+++ b/plugins/voiceSelector.js
@@ -1,0 +1,32 @@
+export function init({ registerButton, playBeep, speak }) {
+  let voices = [];
+
+  function populateVoices() {
+    voices = window.speechSynthesis.getVoices();
+  }
+  populateVoices();
+  if (speechSynthesis.onvoiceschanged !== undefined) {
+    speechSynthesis.onvoiceschanged = populateVoices;
+  }
+
+  registerButton('Voice', () => {
+    playBeep();
+    const content = document.getElementById('content');
+    const list = document.createElement('ul');
+    list.id = 'voice-list';
+    voices.forEach(v => {
+      const li = document.createElement('li');
+      const btn = document.createElement('button');
+      btn.textContent = v.name;
+      btn.addEventListener('click', () => {
+        localStorage.setItem('lcars-voice', v.name);
+        speak(`Voice set to ${v.name}`);
+      });
+      li.appendChild(btn);
+      list.appendChild(li);
+    });
+    content.innerHTML = '<h2>Select Voice</h2>';
+    content.appendChild(list);
+    content.classList.remove('hidden');
+  });
+}

--- a/renderer.js
+++ b/renderer.js
@@ -38,7 +38,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const utter = new SpeechSynthesisUtterance(text);
     utter.rate = 1.0;
     const voices = synth.getVoices();
-    const voice = voices.find(v => /en/i.test(v.lang));
+    const stored = localStorage.getItem('lcars-voice');
+    let voice = null;
+    if (stored) {
+      voice = voices.find(v => v.name === stored);
+    }
+    if (!voice) {
+      voice = voices.find(v => /en/i.test(v.lang));
+    }
     if (voice) utter.voice = voice;
     synth.speak(utter);
   }


### PR DESCRIPTION
## Summary
- implement voice selection persistence in `renderer.js`
- add new `voiceSelector` plugin
- enable the plugin in the plugin list
- document usage of the voice selection feature

## Testing
- `npm install --silent`

------
https://chatgpt.com/codex/tasks/task_e_68573f15125c83278e282c64cd46d222